### PR TITLE
Do not allow DeviceModel.Capabilities to be null

### DIFF
--- a/DuoSecurity.Auth.Http/DuoSecurity.Auth.Http.csproj
+++ b/DuoSecurity.Auth.Http/DuoSecurity.Auth.Http.csproj
@@ -26,6 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 </Project>

--- a/DuoSecurity.Auth.Http/DuoSecurity.Auth.Http.csproj
+++ b/DuoSecurity.Auth.Http/DuoSecurity.Auth.Http.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>1.0.1-beta</Version>
@@ -11,7 +10,7 @@
     <PackageTags>Duo DuoSecurity REST API Auth TwoFactor 2FA HttpClient</PackageTags>
     <PackageReleaseNotes>Add `configureawait` and cancellation token support.</PackageReleaseNotes>
     <Copyright>Joshua Studt 2019</Copyright>
-    <PackageLicenseUrl>https://github.com/orionstudt/DuoSecurity.Auth.Http/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -23,7 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <None Include="..\$(PackageLicenseFile)" Pack="true" PackagePath=""/>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+  </ItemGroup>
 </Project>

--- a/DuoSecurity.Auth.Http/JsonModels/DeviceModel.cs
+++ b/DuoSecurity.Auth.Http/JsonModels/DeviceModel.cs
@@ -8,7 +8,19 @@ namespace DuoSecurity.Auth.Http.JsonModels
 {
     internal class DeviceModel
     {
-        public IEnumerable<string> Capabilities { get; set; }
+        private IEnumerable<string> _capabilities;
+
+        public IEnumerable<string> Capabilities
+        {
+            get
+            {
+                if (_capabilities == null)
+                    _capabilities = new List<string>();
+
+                return _capabilities;
+            }
+            set { _capabilities = value; }
+        }
 
         public string Device { get; set; }
 


### PR DESCRIPTION
Fix exception in PreAuthResult constructor for certain token-only devices.