### PR TITLE
PreAuthByUsernameAsync Exception

### DIFF
--- a/DuoSecurity.Auth.Http/JsonModels/DeviceModel.cs
+++ b/DuoSecurity.Auth.Http/JsonModels/DeviceModel.cs
@@ -5,7 +5,7 @@ namespace DuoSecurity.Auth.Http.JsonModels
 {
     internal class DeviceModel
     {
-        private IEnumerable<string> _capabilities = Enumerable.Empty<string>();
+        private IEnumerable<string> _capabilities;
 
         public IEnumerable<string> Capabilities
         {

--- a/DuoSecurity.Auth.Http/JsonModels/DeviceModel.cs
+++ b/DuoSecurity.Auth.Http/JsonModels/DeviceModel.cs
@@ -1,16 +1,15 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace DuoSecurity.Auth.Http.JsonModels
 {
     internal class DeviceModel
     {
-        private IEnumerable<string> _capabilities;
+        private ICollection<string> _capabilities = new List<string>();
 
-        public IEnumerable<string> Capabilities
+        public ICollection<string> Capabilities
         {
             get => _capabilities;
-            set => _capabilities = value ?? Enumerable.Empty<string>();
+            set => _capabilities = value ?? new List<string>();
         }
 
         public string Device { get; set; }

--- a/DuoSecurity.Auth.Http/JsonModels/PreAuthResultModel.cs
+++ b/DuoSecurity.Auth.Http/JsonModels/PreAuthResultModel.cs
@@ -1,22 +1,21 @@
 ﻿using DuoSecurity.Auth.Http.Abstraction;
 using DuoSecurity.Auth.Http.Results;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace DuoSecurity.Auth.Http.JsonModels
 {
     internal class PreAuthResultModel : IJsonModel<PreAuthResult>
     {
-        private IEnumerable<DeviceModel> _devices;
+        private ICollection<DeviceModel> _devices = new List<DeviceModel>();
 
         public string Result { get; set; }
 
         public string Status_Msg { get; set; }
 
-        public IEnumerable<DeviceModel> Devices
+        public ICollection<DeviceModel> Devices
         {
             get => _devices;
-            set => _devices = value ?? Enumerable.Empty<DeviceModel>();
+            set => _devices = value ?? new List<DeviceModel>();
         }
 
         public string Enroll_Portal_Url { get; set; }

--- a/DuoSecurity.Auth.Http/JsonModels/PreAuthResultModel.cs
+++ b/DuoSecurity.Auth.Http/JsonModels/PreAuthResultModel.cs
@@ -7,7 +7,7 @@ namespace DuoSecurity.Auth.Http.JsonModels
 {
     internal class PreAuthResultModel : IJsonModel<PreAuthResult>
     {
-        private IEnumerable<DeviceModel> _devices = Enumerable.Empty<DeviceModel>();
+        private IEnumerable<DeviceModel> _devices;
 
         public string Result { get; set; }
 


### PR DESCRIPTION
PreAuthByUsernameAsync produces an exception. I've removed Enumerable.Empty and it seems to have resolved issue.

      Unhandled exception rendering component: Cannot create and populate list type System.Linq.EmptyPartition`1[DuoSecurity.Auth.Http.JsonModels.DeviceModel]. Path 'response.devices', line 1, position 26.
      Newtonsoft.Json.JsonSerializationException: Cannot create and populate list type System.Linq.EmptyPartition`1[DuoSecurity.Auth.Http.JsonModels.DeviceModel]. Path 'response.devices', line 1, position 26.